### PR TITLE
Detect and generate MD files to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Open Source Project 0.1
 
 jun-ssg is a simple html generator.
 You can extract your file contents and put them as HTML content.
+The input file can be MarkDown or text file.
 
 ## Usage
 


### PR DESCRIPTION
Added a new function called [`mdToHTML()`](https://github.com/JiaHua-Zou/jun-ssg/commit/e6c02c55b9e1287c7478fb7a826c82f57e8cca5d#diff-87d7a96211bcbd52297c8151003ac3b9ac8a1003b7aac5a41337d261a6a0233eR58-R95)
- The function will convert MD files to HTML.
- All of the headers will be converted depending on the sizes. 

add an `if` statement in the [`convertFilesToHTML()`](https://github.com/JiaHua-Zou/jun-ssg/commit/e6c02c55b9e1287c7478fb7a826c82f57e8cca5d#diff-87d7a96211bcbd52297c8151003ac3b9ac8a1003b7aac5a41337d261a6a0233eR124-R132) function.
- Detects if the input file is `.md` or `.txt`.

Update README.md file [Here](https://github.com/JiaHua-Zou/jun-ssg/commit/f3b1d9b202f0f63f7c29062d911dd41f81814efd#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10)

If there anything that wants to be adjust let me know.